### PR TITLE
Add npm repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "performance testing"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DanielMSchmidt/jest-environment-artillery.git"
+  },
   "bugs": {
     "url": "https://github.com/DanielMSchmidt/jest-environment-artillery/issues"
   },


### PR DESCRIPTION
## Summary

- add standard npm `repository` metadata to `package.json`
- keep runtime code, dependencies, package version, homepage, bugs metadata, and package contents unchanged

## Reproduction

Current published metadata omits `repository`:

```sh
npm view jest-environment-artillery@0.0.2 name version repository homepage bugs license --json
```

After this change, local `package.json` exposes:

- `repository.url`: `git+https://github.com/DanielMSchmidt/jest-environment-artillery.git`

## Validation

```sh
node -e "const p=require('./package.json'); if (p.name !== 'jest-environment-artillery') throw new Error('wrong package'); if (p.repository.url !== 'git+https://github.com/DanielMSchmidt/jest-environment-artillery.git') throw new Error('repository metadata missing'); if (p.homepage !== 'https://github.com/DanielMSchmidt/jest-environment-artillery#readme') throw new Error('homepage changed'); if (p.bugs.url !== 'https://github.com/DanielMSchmidt/jest-environment-artillery/issues') throw new Error('bugs changed'); console.log('metadata ok')"
npm pack --dry-run --ignore-scripts --json .
git diff --check
```
